### PR TITLE
feat: fallback to dweb redirect when status unavailable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1368,9 +1368,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -5112,15 +5112,6 @@
         "uuid": "8.3.2"
       }
     },
-    "node_modules/toucan-js/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -5534,6 +5525,15 @@
         "cookie": "^0.4.1",
         "mustache": "^4.2.0",
         "stack-trace": "0.0.10"
+      }
+    },
+    "node_modules/youch/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     }
   },
@@ -6579,9 +6579,9 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "dev": true
     },
     "core-util-is": {
@@ -9241,14 +9241,6 @@
         "cookie": "0.5.0",
         "stacktrace-js": "2.0.2",
         "uuid": "8.3.2"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-          "dev": true
-        }
       }
     },
     "tr46": {
@@ -9575,6 +9567,14 @@
         "cookie": "^0.4.1",
         "mustache": "^4.2.0",
         "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+          "dev": true
+        }
       }
     }
   }

--- a/src/env.js
+++ b/src/env.js
@@ -7,6 +7,7 @@ import { Logging } from './logs.js'
  * @typedef {Object} EnvInput
  * @property {string} IPFS_GATEWAYS
  * @property {string} GATEWAY_HOSTNAME
+ * @property {string} STATUS_CHECK_URL
  * @property {string} VERSION
  * @property {string} SENTRY_RELEASE
  * @property {string} COMMITHASH
@@ -15,21 +16,11 @@ import { Logging } from './logs.js'
  * @property {string} ENV
  * @property {string} [SENTRY_DSN]
  * @property {string} [LOGTAIL_TOKEN]
- * @property {number} [REQUEST_TIMEOUT]
- * @property {Object} GATEWAYMETRICS
- * @property {Object} SUMMARYMETRICS
- * @property {Object} CIDSTRACKER
- * @property {Object} GATEWAYREDIRECTCOUNTER
- * @property {KVNamespace} DENYLIST
  *
  * @typedef {Object} EnvTransformed
  * @property {string} IPFS_GATEWAY_HOSTNAME
  * @property {string} IPNS_GATEWAY_HOSTNAME
  * @property {Array<string>} ipfsGateways
- * @property {DurableObjectNamespace} gatewayMetricsDurable
- * @property {DurableObjectNamespace} summaryMetricsDurable
- * @property {DurableObjectNamespace} cidsTrackerDurable
- * @property {DurableObjectNamespace} gatewayRedirectCounter
  * @property {number} REQUEST_TIMEOUT
  * @property {Toucan} [sentry]
  * @property {Logging} [log]

--- a/test/ipfs-path.spec.js
+++ b/test/ipfs-path.spec.js
@@ -35,7 +35,7 @@ test('should resolve a cid v0 with IPFS canonical resolution', async (t) => {
   t.is(response.status, 302)
   t.is(
     response.headers.get('location'),
-    'https://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.ipfs.localhost:8787/'
+    'https://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.ipfs.nftstorage.link/'
   )
 })
 
@@ -49,7 +49,7 @@ test('should resolve a cid v1 with IPFS canonical resolution', async (t) => {
   t.is(response.status, 302)
   t.is(
     response.headers.get('location'),
-    'https://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.localhost:8787/'
+    'https://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.nftstorage.link/'
   )
 })
 
@@ -63,7 +63,7 @@ test('should resolve a cid and path with IPFS canonical resolution', async (t) =
   t.is(response.status, 302)
   t.is(
     response.headers.get('location'),
-    'https://bafybeifvsmjgbhck72pabliifeo35cew5yhxujfqjxg4g32vr3yv24h6zu.ipfs.localhost:8787/path/file.txt'
+    'https://bafybeifvsmjgbhck72pabliifeo35cew5yhxujfqjxg4g32vr3yv24h6zu.ipfs.nftstorage.link/path/file.txt'
   )
 })
 
@@ -71,13 +71,13 @@ test('should resolve a cid and path with IPFS canonical resolution when subdomai
   const { mf } = t.context
 
   const response = await mf.dispatchFetch(
-    'https://bafybeifvsmjgbhck72pabliifeo35cew5yhxujfqjxg4g32vr3yv24h6zu.ipfs.localhost:8787/ipfs/bafybeifvsmjgbhck72pabliifeo35cew5yhxujfqjxg4g32vr3yv24h6zu/path/file.txt'
+    'https://bafybeifvsmjgbhck72pabliifeo35cew5yhxujfqjxg4g32vr3yv24h6zu.ipfs.nftstorage.link/ipfs/bafybeifvsmjgbhck72pabliifeo35cew5yhxujfqjxg4g32vr3yv24h6zu/path/file.txt'
   )
   await response.waitUntil()
   t.is(response.status, 302)
   t.is(
     response.headers.get('location'),
-    'https://bafybeifvsmjgbhck72pabliifeo35cew5yhxujfqjxg4g32vr3yv24h6zu.ipfs.localhost:8787/path/file.txt'
+    'https://bafybeifvsmjgbhck72pabliifeo35cew5yhxujfqjxg4g32vr3yv24h6zu.ipfs.nftstorage.link/path/file.txt'
   )
 })
 
@@ -92,7 +92,7 @@ test('should resolve a cid IPFS canonical resolution keeping query parameters', 
   t.is(response.status, 302)
   t.is(
     response.headers.get('location'),
-    `https://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.localhost:8787/${queryString}`
+    `https://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.nftstorage.link/${queryString}`
   )
 })
 
@@ -106,6 +106,6 @@ test('should resolve a cid IPFS canonical resolution with same path as IPFS path
   t.is(response.status, 302)
   t.is(
     response.headers.get('location'),
-    'https://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.localhost:8787/ipfs/bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq'
+    'https://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.nftstorage.link/ipfs/bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq'
   )
 })

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -24,8 +24,9 @@ zone_id = "7eee3323c1b35b6650568604c65f441e"    # web3.storage zone
 route = "link.web3.storage/*"
 
 [env.production.vars]
-IPFS_GATEWAYS = "[\"https://dweb.link\"]"
+IPFS_GATEWAYS = "[\"ipfs.dweb.link\"]"
 GATEWAY_HOSTNAME = 'ipfs.nftstorage.link'
+STATUS_CHECK_URL = 'https://api.nftstoragestatus.com/'
 DEBUG = "false"
 ENV = "production"
 
@@ -37,8 +38,9 @@ zone_id = "7eee3323c1b35b6650568604c65f441e"    # web3.storage zone
 route = "link-staging.web3.storage/*"
 
 [env.staging.vars]
-IPFS_GATEWAYS = "[\"https://dweb.link\"]"
+IPFS_GATEWAYS = "[\"ipfs.dweb.link\"]"
 GATEWAY_HOSTNAME = 'ipfs.nftstorage.link'
+STATUS_CHECK_URL = 'https://api.nftstoragestatus.com/'
 DEBUG = "true"
 ENV = "staging"
 
@@ -47,8 +49,9 @@ ENV = "staging"
 workers_dev = true
 
 [env.test.vars]
-IPFS_GATEWAYS = "[\"https://dweb.link\"]"
-GATEWAY_HOSTNAME = 'ipfs.localhost:8787'
+IPFS_GATEWAYS = "[\"ipfs.dweb.link\"]"
+GATEWAY_HOSTNAME = 'ipfs.nftstorage.link'
+STATUS_CHECK_URL = 'https://api.nftstoragestatus.com/'
 DEBUG = "true"
 ENV = "test"
 
@@ -58,5 +61,6 @@ workers_dev = true
 account_id = "7ec0b7cf2ec201b2580374e53ba5f37b"
 
 [env.vsantos.vars]
-GATEWAY_HOSTNAME = 'ipfs.localhost:8787'
-IPFS_GATEWAYS = "[\"https://ipfs.io\"]"
+GATEWAY_HOSTNAME = 'ipfs.nftstorage.link'
+IPFS_GATEWAYS = "[\"ipfs.dweb.link\"]"
+STATUS_CHECK_URL = 'https://api.nftstoragestatus.com/'


### PR DESCRIPTION
Adds fallback from `nftstorage.link` by checking https://github.com/nftstorage/nftstorage.link/tree/main/packages/status-api and if OK we can go ahead and redirect to there. Otherwise, we use fallback