### PR TITLE
feat: any-url style redirection

### DIFF
--- a/src/any-url.js
+++ b/src/any-url.js
@@ -2,7 +2,7 @@ import { InvalidUrlError } from './errors.js'
 import { findPathUrl } from './utils/cid'
 
 /**
- * Handle gateway request
+ * Handle any url request
  *
  * @param {Request} request
  * @param {import('./env').Env} env

--- a/src/any-url.js
+++ b/src/any-url.js
@@ -1,0 +1,13 @@
+import { InvalidUrlError } from './errors.js'
+import { findPathUrl } from './utils/cid'
+
+/**
+ * Handle gateway request
+ *
+ * @param {Request} request
+ * @param {import('./env').Env} env
+ */
+export async function anyUrlGet (request, env) {
+  const url = findPathUrl(new URL(request.url), env.IPFS_GATEWAY_HOSTNAME)
+  return Response.redirect(url, 302)  
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 import { Router } from 'itty-router'
 
 import { ipfsGet } from './ipfs.js'
+import { anyUrlGet } from './any-url.js'
 
 import { addCorsHeaders, withCorsHeaders } from './cors.js'
 import { errorHandler } from './error-handler.js'
@@ -16,6 +17,7 @@ router
   .get('/ipfs/:cid/*', withCorsHeaders(ipfsGet))
   .head('/ipfs/:cid', withCorsHeaders(ipfsGet))
   .head('/ipfs/:cid/*', withCorsHeaders(ipfsGet))
+  .get('*', withCorsHeaders(anyUrlGet))
 
 /**
  * @param {Error} error

--- a/src/utils/cid.js
+++ b/src/utils/cid.js
@@ -32,3 +32,41 @@ export function normalizeCid(cid) {
   const c = CID.parse(cid)
   return c.toV1().toString()
 }
+
+export function cidToGatewayUrl({cid, path, search = ''}, gatewayHost) {
+  // Parse and normalize CID
+  let nCid
+  try {
+    nCid = normalizeCid(cid)
+  } catch (err) {
+    throw new InvalidUrlError(`invalid CID: ${cid}: ${err.message}`)
+  }
+  return new URL(
+    `https://${nCid}.${gatewayHost}${path}${search}`
+  )
+}
+
+// https://link.xyz/https://example.org => https://example.org
+// https://link.xyz/https://gw.exz/ipfs/<cid>/<path> => https://<cid>.ipfs.nftstorage.link/path
+// https://link.xyz/ipfs://<cid>/<path> => ipfs://<cid>/<path> => https://<cid>.ipfs.nftstorage.link/path
+
+export function findPathUrl ({ pathname, search }, gatewayHost) {
+  const urlStr = pathname.substring(1)
+  if (urlStr.startsWith('ipfs://')) {
+    const cidPath = urlStr.substring('ipfs://'.length)
+    const [cid, ...rest] = cidPath.split('/')
+    return cidToGatewayUrl({ cid, path: '/' + rest.join('/'), search }, gatewayHost)
+  }
+  let url
+  try {
+    url = new URL(urlStr + search)
+  } catch (err) {
+    throw new InvalidUrlError(`invalid url ${urlStr}`)
+  }
+  if (url.pathname.startsWith('/ipfs/')) {
+    const [ _, cid, ...rest ] = url.pathname.substring(1).split('/')
+    return cidToGatewayUrl({ cid, path: '/' + rest.join('/'), search }, gatewayHost)
+  }
+  // otherwise pass thru.
+  return url
+}

--- a/test/cid.spec.js
+++ b/test/cid.spec.js
@@ -1,0 +1,21 @@
+import test from 'ava'
+import { findPathUrl } from '../src/utils/cid.js'
+
+const pathUrls = [
+  ['https://link.xyz/https://example.org', 'https://example.org/'],
+  ['https://link.xyz/https://example.org/foo', 'https://example.org/foo'],
+  ['https://link.xyz/https://example.org/foo?bar=nards', 'https://example.org/foo?bar=nards'],
+  ['https://link.xyz/ipfs://bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy', 'https://bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy.ipfs.nftstorage.link/'],
+  ['https://link.xyz/ipfs://bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy/', 'https://bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy.ipfs.nftstorage.link/'],
+  ['https://link.xyz/ipfs://bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy/foo', 'https://bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy.ipfs.nftstorage.link/foo'],
+  ['https://link.xyz/https://gw.io/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy', 'https://bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy.ipfs.nftstorage.link/'],
+  ['https://link.xyz/https://gw.io/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy/', 'https://bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy.ipfs.nftstorage.link/'],
+  ['https://link.xyz/https://gw.io/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy/foo', 'https://bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy.ipfs.nftstorage.link/foo']
+]
+
+test('findPathUrl', (t) => {
+  for (const [input, expected] of pathUrls) {
+    const output = findPathUrl(new URL(input), 'ipfs.nftstorage.link').toString()
+    t.is(output, expected, `${input}`)
+  }
+})


### PR DESCRIPTION
allow arbitrary url as path. if it's a cid url, then redirect to nftstorage.link otherwise pass thu, just redirec to the given url.

see: https://github.com/nftstorage/nft.storage/issues/1435

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>