### PR TITLE
fix: different url implementation

### DIFF
--- a/src/any-url.js
+++ b/src/any-url.js
@@ -1,4 +1,3 @@
-import { InvalidUrlError } from './errors.js'
 import { findPathUrl } from './utils/cid'
 
 /**
@@ -8,6 +7,6 @@ import { findPathUrl } from './utils/cid'
  * @param {import('./env').Env} env
  */
 export async function anyUrlGet (request, env) {
-  const url = findPathUrl(new URL(request.url), env.IPFS_GATEWAY_HOSTNAME)
+  const url = findPathUrl(request.url, env.IPFS_GATEWAY_HOSTNAME)
   return Response.redirect(url, 302)  
 }

--- a/src/utils/cid.js
+++ b/src/utils/cid.js
@@ -50,8 +50,10 @@ export function cidToGatewayUrl({cid, path, search = ''}, gatewayHost) {
 // https://link.xyz/https://gw.exz/ipfs/<cid>/<path> => https://<cid>.ipfs.nftstorage.link/path
 // https://link.xyz/ipfs://<cid>/<path> => ipfs://<cid>/<path> => https://<cid>.ipfs.nftstorage.link/path
 
-export function findPathUrl ({ pathname, search }, gatewayHost) {
-  const urlStr = pathname.substring(1)
+export function findPathUrl (reqUrl, gatewayHost) {
+  const { origin, hash, search } = new URL(reqUrl)
+  // URL.pathname implementation in CF is different, one "/" is lost in the URL path
+  const urlStr = reqUrl.replace(origin, '').replace(hash, '').replace(search, '').substring(1)
   if (urlStr.startsWith('ipfs://')) {
     const cidPath = urlStr.substring('ipfs://'.length)
     const [cid, ...rest] = cidPath.split('/')

--- a/test/cid.spec.js
+++ b/test/cid.spec.js
@@ -15,7 +15,7 @@ const pathUrls = [
 
 test('findPathUrl', (t) => {
   for (const [input, expected] of pathUrls) {
-    const output = findPathUrl(new URL(input), 'ipfs.nftstorage.link').toString()
+    const output = findPathUrl(input, 'ipfs.nftstorage.link').toString()
     t.is(output, expected, `${input}`)
   }
 })


### PR DESCRIPTION
CF Worker URL implementation is different.

https://link.web3.storage/https://ipfs.io/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy results in path  `https:/ipfs.io/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy`. So, we need to manually get the path